### PR TITLE
Minor fixes for build and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,20 @@ Asteroid_app is a set of tools for minor planet researchers and enthusiasts, use
 
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg)](https://choosealicense.com/licenses/mit/)
 
+## Requirements
+
+In order to build and develop the application, you need:
+
+1. [Node, npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) installed, minimum version 18
+2. [Rust environment and cargo packager](https://www.rust-lang.org/tools/install) installed
+
 ## Installation
-1. You need to have Node, npm, Rust environment and cargo packager
-2. Install packages and dependencies
+
+1. Install packages and dependencies
 ```bash
   npm install
 ```
-3. Build executable
+2. Build executable
 ```bash
   npm tauri build
 ```
@@ -22,13 +29,13 @@ Asteroid_app is a set of tools for minor planet researchers and enthusiasts, use
 Clone the project
 
 ```bash
-  git clone https://github.com/ziriuz84/asteroid_app.git
+  git clone git@github.com:ziriuz84/asteroid_app.git
 ```
 
 Go to the project directory
 
 ```bash
-  cd my-project
+  cd asteroid_app
 ```
 
 Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -907,7 +907,7 @@
       "peerDependencies": {
         "@mantine/core": "7.17.3",
         "@mantine/hooks": "7.17.3",
-gg        "react": "^18.x || ^19.x",
+        "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x"
       }
     },


### PR DESCRIPTION
In this PR : 
- Fixed the `package-lock.json` that contained a typo.
- Minor fixes and improvement to readme.md
    - Indicated requirements for both dev and build, with proper min versions
    - Changed URL for clone from https to ssh (github disabled user/password auth). 
    - Fixed app folder

I have some troubles managing libs conflicts on my Ubuntu 24.04, that's the main dev env I use. So I hope to find out a workaround and document it soon, I'm goint to open a separate issue to fix for this, so I can gather suggestions

## Summary by Sourcery

Update README with clearer installation instructions and project setup details

Documentation:
- Clarified project requirements by adding specific Node and Rust version information
- Updated installation steps to be more precise and accurate
- Changed clone instructions from HTTPS to SSH protocol

Chores:
- Corrected project directory name in README instructions